### PR TITLE
Fixed the OxmlElement import error

### DIFF
--- a/gen_docx_with_rtf_altchunk.py
+++ b/gen_docx_with_rtf_altchunk.py
@@ -2,7 +2,7 @@
 import sys
 import os
 from docx import Document
-from docx.oxml import OxmlElement
+from docx.oxml.parser import OxmlElement
 from docx.oxml.ns import qn
 from docx.opc.part import Part
 from docx.opc.constants import RELATIONSHIP_TYPE as RT


### PR DESCRIPTION
I was trying to run your script but noticed that after a recent update to the docx module, the OxmlElement import produced an error. It can simply be fixed by importing from docx.oxml.parser (instead of docx.oxml).

Obviously a tiny issue so feel free to reject the pull request and add it yourself if but I figured it might help some other ppl out.

Awesome script btw! :)